### PR TITLE
Github optional email

### DIFF
--- a/src/multi_auth/providers/github.cr
+++ b/src/multi_auth/providers/github.cr
@@ -31,7 +31,7 @@ class MultiAuth::Provider::Github < MultiAuth::Provider
     JSON.mapping(
       id: {type: String, converter: String::RawConverter},
       name: String,
-      email: String,
+      email: String?,
       login: String,
       location: String?,
       bio: String?,


### PR DESCRIPTION
Actually, email is an optional field in the response. So, for users who don't want to show their emails, we have a Runtime Error. This change is about to fix this.