### PR TITLE
Fix for missing Google Profile fields, Deprecation Fix, Typo Fix

### DIFF
--- a/spec/providers/google_spec.cr
+++ b/spec/providers/google_spec.cr
@@ -50,7 +50,7 @@ describe MultiAuth::Provider::Google do
             })
         )
 
-        WebMock.stub(:get, "https://people.googleapis.com/v1/people/me?requestMask.includeField=person.addresses,person.biographies,person.bragging_rights,person.cover_photos,person.email_addresses,person.im_clients,person.interests,person.names,person.nicknames,person.phone_numbers,person.photos,person.urls")
+        WebMock.stub(:get, "https://people.googleapis.com/v1/people/me?personFields=addresses,biographies,bragging_rights,cover_photos,email_addresses,im_clients,interests,names,nicknames,phone_numbers,photos,urls")
                .to_return(body: File.read("spec/support/google_api_disabled.json"))
 
         expect_raises(Exception) do

--- a/spec/providers/google_spec.cr
+++ b/spec/providers/google_spec.cr
@@ -23,7 +23,7 @@ describe MultiAuth::Provider::Google do
           })
       )
 
-      WebMock.stub(:get, "https://people.googleapis.com/v1/people/me?requestMask.includeField=person.addresses,person.biographies,person.bragging_rights,person.cover_photos,person.email_addresses,person.im_clients,person.interests,person.names,person.nicknames,person.phone_numbers,person.photos,person.urls")
+      WebMock.stub(:get, "https://people.googleapis.com/v1/people/me?personFields=addresses,biographies,bragging_rights,cover_photos,email_addresses,im_clients,interests,names,nicknames,phone_numbers,photos,urls")
              .to_return(body: File.read("spec/support/google.json"))
 
       user = MultiAuth.make("google", "/callback").user({"code" => "123"}).as(MultiAuth::User)

--- a/src/multi_auth/providers/google.cr
+++ b/src/multi_auth/providers/google.cr
@@ -39,21 +39,21 @@ class MultiAuth::Provider::Google < MultiAuth::Provider
     access_token.authenticate(api)
 
     fields = [
-      "person.addresses",
-      "person.biographies",
-      "person.bragging_rights",
-      "person.cover_photos",
-      "person.email_addresses",
-      "person.im_clients",
-      "person.interests",
-      "person.names",
-      "person.nicknames",
-      "person.phone_numbers",
-      "person.photos",
-      "person.urls",
+      "addresses",
+      "biographies",
+      "bragging_rights",
+      "cover_photos",
+      "email_addresses",
+      "im_clients",
+      "interests",
+      "names",
+      "nicknames",
+      "phone_numbers",
+      "photos",
+      "urls",
     ].join(",")
 
-    raw_json = api.get("/v1/people/me?requestMask.includeField=#{fields}").body
+    raw_json = api.get("/v1/people/me?personFields=#{fields}").body
 
     build_user(raw_json, access_token)
   end
@@ -65,7 +65,9 @@ class MultiAuth::Provider::Google < MultiAuth::Provider
   end
 
   private def primary?(field)
-    json[field].each do |item|
+    field = json[field]?
+    return nil if field.nil?
+    field.each do |item|
       return item if item["metadata"]["primary"].as_bool?
     end
     nil
@@ -82,7 +84,7 @@ class MultiAuth::Provider::Google < MultiAuth::Provider
     name = primary("names")
 
     user = User.new(
-      "github",
+      "google",
       json["resourceName"].as_s,
       name["displayName"].as_s,
       raw_json,


### PR DESCRIPTION
Updated to use personFields instead of deprecated requestMask. User returned from google provider had github provider. Google provider should not crash if user's profile doesn't include one of the personFields we requested.