### PR TITLE
include scope in Amber example

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ end
 # src/controllers/multi_auth_controller.cr
 class MultiAuthController < ApplicationController
   def new
-    redirect_to multi_auth.authorize_uri
+    redirect_to multi_auth.authorize_uri(scope: "email")
   end
 
   def callback


### PR DESCRIPTION
Include scope in the Amber example.  Without it, the request will ask for more permissions than needed.