### PR TITLE
Add missing redirect_uri to gitlab provider

### DIFF
--- a/spec/providers/gitlab_spec.cr
+++ b/spec/providers/gitlab_spec.cr
@@ -3,14 +3,14 @@ require "../spec_helper"
 describe MultiAuth::Provider::Gitlab do
   it "generates authorize_uri" do
     uri = MultiAuth.make("gitlab", "/callback").authorize_uri
-    uri.should eq("https://gitlab.com/oauth/authorize?client_id=gitlab_id&redirect_uri=&response_type=code&scope=")
+    uri.should eq("https://gitlab.com/oauth/authorize?client_id=gitlab_id&redirect_uri=%2Fcallback&response_type=code&scope=")
   end
 
   it "fetch user" do
     WebMock.wrap do
       WebMock.stub(:post, "https://gitlab.com/oauth/token")
         .with(
-          body: "client_id=gitlab_id&client_secret=gitlab_secret&redirect_uri=&grant_type=authorization_code&code=123",
+          body: "client_id=gitlab_id&client_secret=gitlab_secret&redirect_uri=%2Fcallback&grant_type=authorization_code&code=123",
           headers: {"Accept" => "application/json", "Content-type" => "application/x-www-form-urlencoded"}
         )
         .to_return(

--- a/src/multi_auth/providers/gitlab.cr
+++ b/src/multi_auth/providers/gitlab.cr
@@ -69,6 +69,7 @@ class MultiAuth::Provider::Gitlab < MultiAuth::Provider
       secret,
       authorize_uri: "/oauth/authorize",
       token_uri: "/oauth/token",
+      redirect_uri: redirect_uri,
       auth_scheme: :request_body
     )
   end


### PR DESCRIPTION
I made a mistake in the tests of my previous PR and also in the code.

This PR corrects the consideration of the redirect_uri for the Gitlab provider