### PR TITLE
Update shard.yml to support Crystal v1.0.0

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -4,7 +4,7 @@ version: 1.1.1
 authors:
   - Sergey Makridenkov <s@msa7.ru>
 
-crystal: 0.35.1
+crystal: ">= 0.35.1, < 2.0.0"
 
 license: MIT
 


### PR DESCRIPTION
The Travis CI are already testing against `latest`, so we should be in the clear.

I mimicked what the Lucky and PG shards are doing for pre and post 1.0 support: https://github.com/will/crystal-pg/blob/master/shard.yml