### PR TITLE
Switch to GitHub actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,55 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+  schedule:
+    - cron: "0 3 * * MON"
+  workflow_dispatch:
+
+jobs:
+  LintAndTest:
+    strategy:
+      fail-fast: false
+      matrix:
+        crystal_version:
+          - 0.35.1
+          - 0.36.1
+          - latest
+        experimental: [false]
+        include:
+          - crystal_version: nightly
+            experimental: true
+
+    runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.experimental }}
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: oprypin/install-crystal@v1
+        with:
+          crystal: ${{matrix.crystal_version}}
+
+      - name: Check format
+        run: crystal tool format --check
+
+      - name: Set up Crystal cache
+        uses: actions/cache@v2
+        id: crystal-cache
+        with:
+          path: |
+            ~/.cache/crystal
+            lib
+          key: ${{ runner.os }}-crystal-${{ matrix.crystal_version }}-${{ hashFiles('**/shard.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-crystal-${{ matrix.crystal_version }}
+
+      - name: Install shards
+        if: steps.crystal-cache.outputs.cache-hit != 'true'
+        run: shards check || shards install --ignore-crystal-version
+
+      - name: Run tests
+        run: crystal spec

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,0 @@
-dist: xenial
-language: crystal
-crystal:
-- latest

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MultiAuth
 
-[![Build Status](https://travis-ci.org/msa7/multi_auth.svg?branch=master)](https://travis-ci.org/msa7/multi_auth)
+![Build Status](https://github.com/msa7/multi_auth/workflows/CI/badge.svg)
 
 MultiAuth is a library that standardizes multi-provider authentication for web applications. Currently supported providers:
 
@@ -68,7 +68,6 @@ end
 
 ### [Lucky](https://github.com/luckyframework/lucky) integration example
 
-
 ```crystal
 # config/watch.yml
 host: myapp.lvh.me
@@ -107,7 +106,6 @@ end
 ```
 
 ### [Amber](https://github.com/amberframework/amber) integration example
-
 
 ```crystal
 # config/initializers/multi_auth.cr
@@ -168,7 +166,6 @@ end
 
 Install docker
 
-
 Setup everythings
 
 ```
@@ -183,6 +180,7 @@ make t c=spec/providers/twitter_spec.cr
 ```
 
 Run code linter
+
 ```
 make l
 ```


### PR DESCRIPTION
In our current state, we run our tests against _only_ the `latest` Crystal, even though the shard technically supports 0.35, 0.36, and 1.0.

Using GitHub actions provides the following benefits:
- It's free, since this is open source
- We can test against all supported versions easily
- We can test against the nightly build (as experimental, so that tests can fail)