### PR TITLE
Make name optional for OAuth users

### DIFF
--- a/src/multi_auth/providers/github.cr
+++ b/src/multi_auth/providers/github.cr
@@ -38,7 +38,7 @@ class MultiAuth::Provider::Github < MultiAuth::Provider
     @[JSON::Field(converter: String::RawConverter)]
     property id : String
 
-    property name : String
+    property name : String?
     property email : String?
     property login : String
     property location : String?

--- a/src/multi_auth/user.cr
+++ b/src/multi_auth/user.cr
@@ -4,7 +4,7 @@ class MultiAuth::User
 
   getter provider : String
   getter uid : String
-  getter name : String
+  getter name : String?
   getter raw_json : String
   getter access_token : OAuth::AccessToken | OAuth2::AccessToken
 


### PR DESCRIPTION
I was receiving random exceptions in my tracking tool that were originating directly from this shard, to the effect of:

```
JSON::SerializableError
Expected String but was Null at line 1, column 965
  parsing MultiAuth::Provider::Github::GhUser#name at line 1, column 954
```

I was unable to reproduce the error on my end until I went to my [GitHub profile settings](https://github.com/settings/profile) and set the "Name" field to empty. GitHub allows this as a valid update, and I was immediately able to trigger this error any time multi_auth processed a GitHub callback for my user.

This will probably be a breaking change, but I believe that it's necessary as long as we want to use a Nil-able value for the GHUser name field.

An alternative to this PR would be to use the `nickname` (`gh_user.login`) value for the `name` field since that will always be populated.